### PR TITLE
fix: allows type-id init on any output position

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use ckb_std::{
-    ckb_constants::{Source, CKB_SUCCESS},
+    ckb_constants::Source,
     debug,
     error::SysError,
     high_level::{load_cell_type_hash, load_input, load_script, load_script_hash},
@@ -51,10 +51,9 @@ fn locate_first_type_id_output_index() -> Result<usize, Error> {
 
     let mut i = 0;
     loop {
-        let type_hash =
-            load_cell_type_hash(i, Source::Output)?.ok_or(Error::Syscall(SysError::ItemMissing))?;
+        let type_hash = load_cell_type_hash(i, Source::Output)?;
 
-        if type_hash == current_script_hash {
+        if type_hash == Some(current_script_hash) {
             break;
         }
         i += 1

--- a/test-lib/contracts/type-id-test/src/type_id.rs
+++ b/test-lib/contracts/type-id-test/src/type_id.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 use ckb_std::{
-    ckb_constants::{Source, CKB_SUCCESS},
+    ckb_constants::Source,
     debug,
     error::SysError,
     high_level::{load_cell_type_hash, load_input, load_script, load_script_hash},
@@ -34,7 +34,7 @@ impl From<SysError> for Error {
 fn has_type_id_cell(index: usize, source: Source) -> bool {
     let mut buf = Vec::new();
     match load_cell(&mut buf, 0, index, source) {
-        Ok(r) => r as u64 == CKB_SUCCESS,
+        Ok(_) => true,
         Err(e) => {
             // just confirm cell presence, no data needed
             if let SysError::LengthNotEnough(_) = e {
@@ -51,10 +51,9 @@ fn locate_first_type_id_output_index() -> Result<usize, Error> {
 
     let mut i = 0;
     loop {
-        let type_hash =
-            load_cell_type_hash(i, Source::Output)?.ok_or(Error::Syscall(SysError::ItemMissing))?;
+        let type_hash = load_cell_type_hash(i, Source::Output)?;
 
-        if type_hash == current_script_hash {
+        if type_hash == Some(current_script_hash) {
             break;
         }
         i += 1

--- a/test-lib/tests/src/tests.rs
+++ b/test-lib/tests/src/tests.rs
@@ -86,6 +86,80 @@ fn test_type_id_create_success() {
 }
 
 #[test]
+fn test_type_id_create_on_second_output() {
+    // deploy contract
+    let mut context = Context::default();
+    let contract_bin: Bytes = Loader::default().load_binary("type-id-test");
+    let type_id_out_point = context.deploy_cell(contract_bin);
+    let type_script_dep = CellDep::new_builder()
+        .out_point(type_id_out_point.clone())
+        .build();
+
+    // prepare scripts
+    let always_success_out_point = context.deploy_cell(ALWAYS_SUCCESS.clone());
+    let lock_script = context
+        .build_script(&always_success_out_point.clone(), Default::default())
+        .expect("script");
+    let lock_script_dep = CellDep::new_builder()
+        .out_point(always_success_out_point)
+        .build();
+
+    // prepare cells
+    let input_out_point = context.create_cell(
+        CellOutput::new_builder()
+            .capacity(2000u64.pack())
+            .lock(lock_script.clone())
+            .build(),
+        Bytes::new(),
+    );
+    let input = CellInput::new_builder()
+        .previous_output(input_out_point)
+        .build();
+
+    let input_hash = {
+        let mut blake2b = new_blake2b();
+        blake2b.update(input.as_slice());
+        blake2b.update(&1u64.to_le_bytes());
+        let mut ret = [0; 32];
+        blake2b.finalize(&mut ret);
+        Bytes::from(ret.to_vec())
+    };
+
+    let type_id_script = context
+        .build_script(&type_id_out_point, input_hash)
+        .unwrap();
+    let outputs = vec![
+        CellOutput::new_builder()
+            .capacity(1000u64.pack())
+            .lock(lock_script.clone())
+            .build(),
+        CellOutput::new_builder()
+            .capacity(1000u64.pack())
+            .lock(lock_script)
+            .type_(Some(type_id_script.clone()).pack())
+            .build(),
+    ];
+
+    let outputs_data = vec![Bytes::new(); 2];
+
+    // build transaction
+    let tx = TransactionBuilder::default()
+        .input(input)
+        .outputs(outputs)
+        .outputs_data(outputs_data.pack())
+        .cell_dep(lock_script_dep)
+        .cell_dep(type_script_dep)
+        .build();
+    let tx = context.complete_tx(tx);
+
+    // run
+    let cycles = context
+        .verify_tx(&tx, MAX_CYCLES)
+        .expect("pass verification");
+    println!("consume cycles: {}", cycles);
+}
+
+#[test]
 fn test_type_id_create_fail() {
     // deploy contract
     let mut context = Context::default();


### PR DESCRIPTION
there is a limitation on current implementation:  user have to init type-id on first output or on other output position with previous non-empty type script outputs. this PR removed this restriction.

ref: https://github.com/nervosnetwork/ckb-c-stdlib/pull/42